### PR TITLE
New URLs for listing pickups #48 - Filter by multiple statuses

### DIFF
--- a/src/controllers/pickup-controller.js
+++ b/src/controllers/pickup-controller.js
@@ -135,7 +135,20 @@ PickupController.prototype = (function () {
             var path = request.path;
             var segments = path.split("/");
             var lastSegment = segments[segments.length-1];
-            Pickup.filterByStatus(userId, resolveStatusFromRequest(lastSegment))
+            console.log(request.query['status']);
+            Pickup.filterByStatus(userId, [resolveStatusFromRequest(lastSegment)])
+                    .limit(limit)
+                    .sort({createdAt: 'desc'})
+                    .exec()
+                    .then(function (pickups) {
+                        reply(pickups);
+                    });
+        },
+        tracking: function (request, reply) {
+            var userId = request.auth.credentials.user;
+            var limit = request.query['limit'] || 30;
+            var statuses = request.query['status'] || [];
+            Pickup.filterByStatus(userId, statuses.map(resolveStatusFromRequest))
                     .limit(limit)
                     .sort({createdAt: 'desc'})
                     .exec()
@@ -215,7 +228,9 @@ var uploadFile = function (data) {
 var resolveStatusFromRequest = function(statusFromRequest) {
  return {ongoing:       PickupStatus.ON_GOING, 
          waitingreview: PickupStatus.WAITING_REVIEW, 
-         completed:     PickupStatus.COMPLETED}[statusFromRequest]
+         completed:     PickupStatus.COMPLETED,
+         canceled: PickupStatus.CANCELED,
+        }[statusFromRequest]
 }
 
 var changeStatus = function(status, request, reply) {

--- a/src/models/pickup.js
+++ b/src/models/pickup.js
@@ -71,12 +71,12 @@ var Pickup = new Schema({
     timestamps: true
 });
 
-Pickup.statics.filterByStatus = function(userId, status=null) {
+Pickup.statics.filterByStatus = function(userId, statuses=null) {
     var curDate = moment().tz('America/Vancouver');
     var last6Month = curDate.clone().subtract(6, 'months');
     var filter = {requester: userId, time: {"$gte": last6Month}};
-    if(status) {
-        filter.status = status;
+    if(statuses) {
+        filter.status = {"$in": statuses};
     }
     return this.find(filter);
 }

--- a/src/routes/pickup-route.js
+++ b/src/routes/pickup-route.js
@@ -141,6 +141,19 @@ exports.register = function (server, options, next) {
         }
     });
 
+    server.route({
+        method: 'GET',
+        path: '/api/' + version + '/pickups/status-tracking',
+        config: {
+            handler: controllers.PickupController.tracking,
+            validate: validators.PickupValidator.tracking,
+            description: 'Filter pickups by status ordered by date',
+            notes: 'Filter pickups by status ordered by date',
+            tags: ['api'],
+            auth: 'jwt'
+        }
+    });
+
     next();
 
 };

--- a/src/validators/pickup-validator.js
+++ b/src/validators/pickup-validator.js
@@ -30,7 +30,22 @@ PickupValidator.prototype = (function () {
         },
         list: {
             query: {
-                limit: Joi.number().integer().optional().description('Limit total of items returned - Default: 30').example(10),
+                limit: Joi.number().integer().optional()
+                                   .description('Limit total of items returned - Default: 30')
+                                   .example(10),                
+            },
+            headers: schema.authorization.required()
+        },
+        tracking: {
+            query: {
+                limit: Joi.number().integer().optional()
+                                   .description('Limit total of items returned - Default: 30')
+                                   .example(10),
+                status: Joi.array().items(Joi.string().optional()).optional()
+                                   .description('Filter by status. Values allowed: ongoing,'+ 
+                                                'waitingreview, completed, canceled.'+ 
+                                                'Example: /pickups/status-tracking?status='+
+                                                'ongoing&status=waitingreview'),
             },
             headers: schema.authorization.required()
         },


### PR DESCRIPTION
Allows filtering by multiple statuses.

**Example of how to use**: /api/v1.0/pickups/status-tracking?status=ongoing&status=canceled&limit=10

**Values allowed:** _ongoing_, _waitingreview_, _completed_, _canceled_.

Please, referer the API doc for details.
